### PR TITLE
Catch up with main uboone fork

### DIFF
--- a/apps/bdt_convert.cxx
+++ b/apps/bdt_convert.cxx
@@ -4468,12 +4468,6 @@ for (Int_t i = 3; i < argc; ++i) {
       // bnb run 3 high rate
       if (pot.runNo >=15369 && pot.runNo <= 15402) continue;
     }
-    if (skip_cut == 0){
-      // low lifetime, docdb 39787
-      if (pot.runNo >= 19753 && pot.runNo <= 19850) continue;
-      // low lifetime, docdb 40093
-      if (pot.runNo >= 25447 && pot.runNo <= 25512) continue;
-    }
     t2->Fill();
   }
 
@@ -4505,12 +4499,6 @@ for (Int_t i = 3; i < argc; ++i) {
         if ((*pot_tree_it)->runNo >= 8321 && (*pot_tree_it)->runNo <=8404) continue;
         // bnb run 3 high rate
         if ((*pot_tree_it)->runNo >=15369 && (*pot_tree_it)->runNo <= 15402) continue;
-      }
-      if (skip_cut == 0){
-        // low lifetime, docdb 39787
-        if ((*pot_tree_it)->runNo >= 19753 && (*pot_tree_it)->runNo <= 19850) continue;
-        // low lifetime, docdb 40093
-        if ((*pot_tree_it)->runNo >= 25447 && (*pot_tree_it)->runNo <= 25512) continue;
       }
       (*pot_tree_it)->new_pot_tree->Fill();
 

--- a/apps/bdt_convert.cxx
+++ b/apps/bdt_convert.cxx
@@ -96,6 +96,11 @@ Options:
       Path to Wire-Cell BDT training list file
       Format: <type> <run> <subrun>
 
+  -i<string>
+      Path to list of runs which will additionally be removed
+      Format: <run> <subrun1> <subrun2> ...
+      Use <run> -1 to remove all subruns in the run
+
   -g<string>
       Global file type label used with training list
 
@@ -203,6 +208,7 @@ int main( int argc, char** argv )
 
   TString training_list = "";
   string global_file_type = "";
+  TString remove_individual_run_list = "";
   int skip_cut = 0;
   int flag_numi = 0;
 
@@ -257,6 +263,10 @@ for (Int_t i = 3; i < argc; ++i) {
 
     case 'l':
       if (value_ptr) training_list = value_ptr;
+      break;
+
+    case 'i':
+      if (value_ptr) remove_individual_run_list = value_ptr;
       break;
 
     case 'g':
@@ -351,6 +361,31 @@ for (Int_t i = 3; i < argc; ++i) {
     }
     // std::cout << map_type_run_subrun.size() << std::endl;
     // return 0;
+  }
+
+  std::unordered_map<int,std::vector<int>> remove_individual_run;
+  if (remove_individual_run_list != ""){
+    ifstream infile(remove_individual_run_list);
+    if (!infile.good()) {
+      std::cout<<"Unable to open list of individual runs to remove. Exiting"<<std::endl;
+      return 1;
+    }
+    int run;
+    std::vector<int> subrun;
+    std::string lineContent;
+    while(std::getline(infile, lineContent)){
+      run=-1;
+      std::stringstream ss(lineContent);
+      int entry;
+      // Extract each subrun entry from the given line
+      while (ss >> entry) {
+        if(run<0) { run = entry; }
+        else{ 
+          subrun.push_back(entry);
+        }  
+      }
+      remove_individual_run[run] = subrun;
+    }
   }
 
   if (flag_keep_only_bdt_train) {
@@ -4026,7 +4061,24 @@ for (Int_t i = 3; i < argc; ++i) {
       remove_set.insert(std::make_pair(eval.run, eval.subrun));
       continue;
     }
-  
+
+    // Remove runs if they are in the extra list provided 
+    auto rs_it = remove_individual_run.find(eval.run);
+    if (rs_it != remove_individual_run.end()) {
+      // Removing all subruns in this run
+      if ((*rs_it).second.at(0)==-1){
+        remove_set.insert(std::make_pair(eval.run, eval.subrun));
+        continue;
+      }
+      // Check if this subrun is in the list of ones to remove in the given run 
+      auto s_it = std::find((*rs_it).second.begin(), (*rs_it).second.end(), eval.subrun);
+      if (s_it != (*rs_it).second.end()) {
+        remove_set.insert(std::make_pair(eval.run, eval.subrun));
+        continue; 
+      }
+    }
+ 
+    // Remove (or keep) BDT training runs.
     if (flag_check_run_subrun){
       if (flag_use_global_file_type){
 	(*eval.file_type) = global_file_type;
@@ -4098,7 +4150,7 @@ for (Int_t i = 3; i < argc; ++i) {
   T_spacepoints->SetBranchStatus("*",1);
 
   if(flag_set_samdef){
-    t1->Branch("samdef", "TSring", &samdef);
+    t1->Branch("samdef", "TString", &samdef);
   }
 
   int nentries = T_BDTvars->GetEntries();

--- a/apps/bdt_convert.cxx
+++ b/apps/bdt_convert.cxx
@@ -4406,12 +4406,6 @@ for (Int_t i = 3; i < argc; ++i) {
       // bnb run 3 high rate
       if (eval.run >=15369 && eval.run <= 15402) continue;
     }
-    if (skip_cut == 0){
-      // low lifetime, docdb 39787
-      if (eval.run >= 19753 && eval.run <= 19850) continue;
-      // low lifetime, docdb 40093
-      if (eval.run >= 25447 && eval.run <= 25512) continue;
-    }
  
     t4->Fill();
     t1->Fill();

--- a/apps/tree_trimmer.cxx
+++ b/apps/tree_trimmer.cxx
@@ -260,16 +260,6 @@ bool keep_subrun(int run, int subrun,
       }
   }
 
-  if (skip_cut == 0) {
-      if (run >= 19753 && run <= 19850) {
-          return flag_keep_subrun;
-      }
-      if (run >= 25447 && run <= 25512) {
-          return flag_keep_subrun;
-      }
-  }
-
-
   flag_keep_subrun = true;
   return flag_keep_subrun;
 

--- a/apps/tree_trimmer.cxx
+++ b/apps/tree_trimmer.cxx
@@ -130,6 +130,11 @@ Options:
   -l<string>
       Path to Wire-Cell BDT training list file
 
+  -i<string>
+      Path to list of runs which will additionally be removed
+      Format: <run> <subrun1> <subrun2> ...
+      Use <run> -1 to remove all subruns in the run
+
   -g<string>
       Global file type label used with training list
 
@@ -184,7 +189,8 @@ Notes:
 bool keep_subrun(int run, int subrun,
                  int start_run, int start_subrun, int stop_run, int stop_subrun,
                  int remove_lantern_fails, bool haveReco, 
-                 int flag_keep_only_bdt_train, const std::string& global_file_type, const std::map<string, std::set<std::pair<int, int>>>& map_type_run_subrun,
+                 int flag_keep_only_bdt_train, const std::string& global_file_type, const std::map<string, std::set<std::pair<int, int>>>& map_type_run_subrun, 
+                 std::unordered_map<int,std::vector<int>>& remove_individual_run, 
                  int skip_cut, int flag_data, int flag_numi,
                  const std::set<int>& good_runlist_set, const std::set<int>& low_lifetime_set, const std::set<int>& low_neutrino_count_numi_run2RHC_set) {
 
@@ -216,6 +222,20 @@ bool keep_subrun(int run, int subrun,
       } else if (flag_keep_only_bdt_train == 1) {
           return flag_keep_subrun;
       }
+  }
+
+  // Remove runs if they are in the extra list provided 
+  auto rs_it = remove_individual_run.find(run);
+  if (rs_it != remove_individual_run.end()) {
+    // Removing all subruns in this run
+    if ((*rs_it).second.at(0)==-1){
+      return flag_keep_subrun;
+    }
+    // Check if this subrun is in the list of ones to remove in the given run 
+    auto s_it = std::find((*rs_it).second.begin(), (*rs_it).second.end(), subrun);
+    if (s_it != (*rs_it).second.end()) {
+      return flag_keep_subrun;
+    }
   }
 
   // Remove bad run-subruns if the flag is set.
@@ -300,6 +320,8 @@ int main( int argc, char** argv )
   TString training_list = "";
   string global_file_type = "";
   int flag_keep_only_bdt_train = -1;
+
+  TString remove_individual_run_list = "";
 
   int flag_set_samdef = 0;
   TString samdef="";
@@ -454,6 +476,13 @@ int main( int argc, char** argv )
       }
       break;
 
+    case 'i':
+      if (value_ptr){
+        remove_individual_run_list = value_ptr;
+        std::cout<<"Loading list of additionally runs to remove from "<<remove_individual_run_list<<"\n\n";
+      }
+      break;
+
     case 'g':
       if (value_ptr) {
         global_file_type = value_ptr;
@@ -558,6 +587,31 @@ int main( int argc, char** argv )
     }
   }
 
+  // Load list of individual runs to remove
+  std::unordered_map<int,std::vector<int>> remove_individual_run;
+  if (remove_individual_run_list != ""){
+    ifstream infile(remove_individual_run_list);
+    if (!infile.good()) {
+      std::cout<<"Unable to open list of individual runs to remove. Exiting"<<std::endl;
+      return 1;
+    }
+    int run;
+    std::vector<int> subrun;
+    std::string lineContent;
+    while(std::getline(infile, lineContent)){
+      run=-1;
+      std::stringstream ss(lineContent);
+      int entry;
+      // Extract each subrun entry from the given line
+      while (ss >> entry) {
+        if(run<0) { run = entry; }
+        else{
+          subrun.push_back(entry);
+        }
+      }
+      remove_individual_run[run] = subrun;
+    }
+  }
 
   // Check if the output file exists if overwrite is not set.
   if(flag_overwrite!=1){
@@ -671,7 +725,8 @@ int main( int argc, char** argv )
     bool temp_keep_subrun = keep_subrun(run, subrun, 
                                         start_run, start_subrun, stop_run, stop_subrun,
                                         remove_lantern_fails, haveReco, 
-                                        flag_keep_only_bdt_train, global_file_type, map_type_run_subrun,
+                                        flag_keep_only_bdt_train, global_file_type, map_type_run_subrun, 
+                                        remove_individual_run, 
                                         skip_cut, flag_data, flag_numi,
                                         good_runlist_set, low_lifetime_set, low_neutrino_count_numi_run2RHC_set);
 
@@ -813,6 +868,7 @@ int main( int argc, char** argv )
                                                          first_run, first_subrun, last_run, last_subrun, 
                                                          remove_lantern_fails, temp_haveReco, 
                                                          flag_keep_only_bdt_train, global_file_type, map_type_run_subrun,
+                                                         remove_individual_run,
                                                          skip_cut, flag_data, flag_numi,
                                                          good_runlist_set, low_lifetime_set, low_neutrino_count_numi_run2RHC_set);
 


### PR DESCRIPTION
Update to allow tree_trimmer and bdt_convert to use a custom list of run-subruns to remove. This provides additional flexibility, and is intended to replace the hardcoded cut on the zero e-lifetime period runs.